### PR TITLE
Set meta at resolve time and provide some defaults for text and newTab

### DIFF
--- a/src/Link.php
+++ b/src/Link.php
@@ -13,12 +13,35 @@ class Link extends Field
      */
     public $component = 'link';
 
-    public function details($details)
+    /**
+     * The field's details given by the user.
+     *
+     * @var array
+     */
+    private $details;
+
+    public function resolve($resource, $attribute = null)
     {
-        return $this->withMeta([
+        parent::resolve($resource, $attribute);
+
+        $details = array_merge([
+            'text' => function () {
+                return $this->value;
+            },
+            'newTab' => false,
+        ], $this->details);
+
+        $this->withMeta([
             'href' => is_callable($details['href']) ? call_user_func($details['href']) : $details['href'],
             'text' => is_callable($details['text']) ? call_user_func($details['text']) : $details['text'],
             'newTab' => is_callable($details['newTab']) ? call_user_func($details['newTab']) : $details['newTab'],
         ]);
+    }
+
+    public function details($details)
+    {
+        $this->details = $details;
+
+        return $this;
     }
 }


### PR DESCRIPTION
Hey,

Thanks for your package, I often use it and and it has been very helpful.

One thing I notice is that I do almost always the same kind of implementations for `text` and `newTab`, because I only need to customize the link. I want the text to be what is saved in the model, and newTab to false most of the time, because users can use Ctrl + click or  Cmd + click to get a new tab.

So I often use the `Link` field that way:

```php
Link::make('name')->details([
    'href' => function () {
        return "/nova/resources/apps/{$this->team_id}";
    },
    'text' => function () {
        return $this->name;
    },
    'newTab' => false,
])
```

I might be wrong but I think most people just need to customize the link, not the text. So I figured it could be a good idea to make the text default to the value held by the model, and newTab to false.

And that's why I made this PR. The idea is to call the `withMeta` method during resolution of the field, in order to have access to the value.

This allows me to define link like that:

```php
Link::make('name')->details([
    'href' => function () {
        return "/nova/resources/apps/{$this->team_id}";
    },
])
```

Tell me what you think of it!

I only tested it on a Laravel 5.7 / Nova 1.3.2 install, not Nova 2.x.