### PR TITLE
Fix detail view styling

### DIFF
--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- <panel-item :field="field" /> -->
-    <div class="flex border-b border-40">
+    <div class="flex border-b border-40 -mx-6 px-6">
         <div class="w-1/4 py-4">
             <slot>
                 <h4 class="font-normal text-80">


### PR DESCRIPTION
In its present state, the bottom border of the field on the details view doesn't use the full width of a panel, in contrast to first-party Nova fields.

This PR adds a couple classes to bring the styling in line with the overall Nova interface.